### PR TITLE
move center

### DIFF
--- a/assets/css/common.scss
+++ b/assets/css/common.scss
@@ -101,7 +101,7 @@ header{
 		width: 100%;
 		display: flex;
 		justify-content: space-around;
-		padding: 2%;
+    height: 35px;
 		padding-top: 0;
 		list-style: none;
 	}

--- a/assets/css/common.scss
+++ b/assets/css/common.scss
@@ -101,8 +101,7 @@ header{
 		width: 100%;
 		display: flex;
 		justify-content: space-around;
-    height: 35px;
-		padding-top: 0;
+		padding-bottom: 2%;
 		list-style: none;
 	}
 	li{


### PR DESCRIPTION
to #15 
 
Post(？)のヘッダーが真ん中になってなかったのが気になったのでゴリッと直してみました．

before
![screenshot from 2016-03-21 02-15-43](https://cloud.githubusercontent.com/assets/5053237/13906283/21b340d0-ef16-11e5-905b-ed5bcfa4c931.png)

after
![screenshot from 2016-03-21 02-18-21](https://cloud.githubusercontent.com/assets/5053237/13906284/22261e16-ef16-11e5-91ff-8b033a3ff3e5.png)

